### PR TITLE
Added api-version

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -2,6 +2,7 @@ name: SlimefunLuckyBlocks
 version: 1.1
 author: mrCookieSlime
 website: http://dev.bukkit.org/profiles/mrCookieSlime/bukkit-plugins/
+api-version: 1.13
 
 main: me.mrCookieSlime.SlimefunLuckyBlocks.SlimefunLuckyBlocks
 


### PR DESCRIPTION
Added api-version to fix fatal error on load.
```
Fatal error trying to convert SlimefunLuckyBlocks v1.1:me/mrCookieSlime/SlimefunLuckyBlocks/SlimefunLuckyBlocks.class
org.bukkit.plugin.AuthorNagException: No legacy enum constant for OAK_PLANKS. Did you forget to define api-version: 1.13 in your plugin.yml?
```