### PR TITLE
fix spawning

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/WorldGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/WorldGenerator.java
@@ -19,7 +19,7 @@ public class WorldGenerator implements Listener {
 	public void onRandomSpawn(ChunkPopulateEvent e) {
 		if (!plugin.getCfg().getStringList("world-blacklist").contains(e.getWorld().getName()) && plugin.getRandom().nextInt(100) < plugin.getCfg().getInt("chance")) {
 			int x = e.getChunk().getX() * 16 + plugin.getRandom().nextInt(16);
-			int z = e.getChunk().getZ() * 16 + plugin.getRandom().nextInt(16) ;
+			int z = e.getChunk().getZ() * 16 + plugin.getRandom().nextInt(16);
 			int y = e.getWorld().getHighestBlockYAt(x, z);
 			
 	    	Block current = e.getWorld().getBlockAt(x, y, z);

--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/WorldGenerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/WorldGenerator.java
@@ -19,12 +19,15 @@ public class WorldGenerator implements Listener {
 	public void onRandomSpawn(ChunkPopulateEvent e) {
 		if (!plugin.getCfg().getStringList("world-blacklist").contains(e.getWorld().getName()) && plugin.getRandom().nextInt(100) < plugin.getCfg().getInt("chance")) {
 			int x = e.getChunk().getX() * 16 + plugin.getRandom().nextInt(16);
-	    	int z = e.getChunk().getZ() * 16 + plugin.getRandom().nextInt(16);
-	    	int y = e.getWorld().getHighestBlockYAt(x, z) + 1;
+			int z = e.getChunk().getZ() * 16 + plugin.getRandom().nextInt(16) ;
+			int y = e.getWorld().getHighestBlockYAt(x, z);
 			
 	    	Block current = e.getWorld().getBlockAt(x, y, z);
 			if (!current.getType().isSolid() && current.getRelative(BlockFace.DOWN).getType().isSolid()) {
 				plugin.spawnLuckyBlock(current);
+				if (plugin.getCfg().getBoolean("debug")) {
+					plugin.getLogger().info("spawned lucky block at " + current.getX() + " " + current.getY() + " " + current.getZ() + " " + current.getWorld().getName());
+				}
 			}
 		}
 	}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,3 +2,4 @@ world-blacklist:
 - world_nether
 - world_the_end
 chance: 2
+debug: false


### PR DESCRIPTION
[getHighestBlockYAt ](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/World.html#getHighestBlockYAt-int-int-) is inclusive to the air block, so the +1 was unnecessary, and resulted in lucky blocks never spawning in the world