### PR TITLE
CustomItemSurprises

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
@@ -1,6 +1,7 @@
 package io.github.thebusybiscuit.slimefunluckyblocks;
 
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 import io.github.thebusybiscuit.slimefunluckyblocks.surprises.CustomItemSurprise;
 import io.github.thebusybiscuit.slimefunluckyblocks.surprises.LuckLevel;
 import io.github.thebusybiscuit.slimefunluckyblocks.surprises.Surprise;
@@ -71,6 +72,7 @@ import me.mrCookieSlime.Slimefun.cscorelib2.updater.Updater;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 
@@ -214,7 +216,7 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 
 				if (cfg.getValue("custom." + name + ".items") != null && cfg.getKeys("custom." + name + ".items").size() > 0) {
 					for (String itemID : cfg.getKeys("custom." + name + ".items")) {
-						ItemStack item = null;
+						ItemStack item;
 						String itemPath = "custom." + name + ".items." + itemID;
 						if (cfg.getString(itemPath + ".type") != null && Material.getMaterial(cfg.getString(itemPath + ".type")) != null) {
 							item = new ItemStack(Material.getMaterial(cfg.getString(itemPath + ".type")));
@@ -230,35 +232,35 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 
 							if (cfg.getStringList(itemPath + ".lore").size() > 0) {
 								List<String> lore = new ArrayList<>();
-								cfg.getStringList(itemPath + ".lore").forEach(l -> {
+								for (String l : cfg.getStringList(itemPath + ".lore")) {
 									lore.add(ChatColor.translateAlternateColorCodes('&', l));
-								});
+								}
 								itemMeta.setLore(lore);
 							}
 
-
 							if (cfg.getStringList(itemPath + ".enchants").size() > 0) {
-								cfg.getStringList(itemPath + ".enchants").forEach(ench -> {
-									String enchName = ench.split(":")[0];
-									String enchLevel = ench.split(":")[1];
+								for (String ench : cfg.getStringList(itemPath + ".enchants")) {
+									String[] split = ench.split(":");
+									String enchName = split[0];
 									Enchantment enchantment;
 									int level = 0;
 
-									if (Enchantment.getByName(enchName.toUpperCase()) == null) {
+									if (Enchantment.getByName(enchName.toUpperCase(Locale.ROOT)) == null) {
 										getLogger().log(Level.WARNING, "Couldn't set '" + enchName + "' enchant for CustomItem Surprise '" + name + "'");
-										return;
+										continue;
 									}
-									enchantment = Enchantment.getByName(enchName.toUpperCase());
+									enchantment = Enchantment.getByName(enchName.toUpperCase(Locale.ROOT));
 
-									try {
-										level = Integer.parseInt(enchLevel);
-									} catch (NumberFormatException ex) {
-										getLogger().log(Level.WARNING, "Couldn't set '" + enchName + "' enchant with level '" + enchLevel + "' for CustomItem Surprise '" + name + "'");
-										return;
+									if (split.length > 1) {
+										if (!PatternUtils.NUMERIC.matcher(split[1]).matches()) {
+											getLogger().log(Level.WARNING, "Couldn't set '" + enchName + "' enchant with level '" + split[1] + "' for CustomItem Surprise '" + name + "'");
+											continue;
+										}
+										level = Integer.parseInt(split[1]);
 									}
 
 									itemMeta.addEnchant(enchantment, level, true);
-								});
+								}
 							}
 							item.setItemMeta(itemMeta);
 							items.add(item);

--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
@@ -60,6 +60,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.bstats.bukkit.Metrics;
@@ -216,9 +217,22 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 
 				if (cfg.getValue("custom." + name + ".items") != null && cfg.getKeys("custom." + name + ".items").size() > 0) {
 					for (String itemID : cfg.getKeys("custom." + name + ".items")) {
-						ItemStack item;
+						ItemStack item = null;
 						String itemPath = "custom." + name + ".items." + itemID;
-						if (cfg.getString(itemPath + ".type") != null && Material.getMaterial(cfg.getString(itemPath + ".type")) != null) {
+
+						if (cfg.getString(itemPath + ".slimefun_item") != null) {
+							SlimefunItem sfItem = SlimefunItem.getByID(cfg.getString(itemPath + ".slimefun_item").toUpperCase(Locale.ROOT));
+
+							if (sfItem != null) {
+								item = sfItem.getItem();
+
+								if (cfg.getInt(itemPath + ".amount") > 1) {
+									item.setAmount(cfg.getInt(itemPath + ".amount"));
+								}
+							} else {
+								getLogger().log(Level.WARNING, "Couldn't load SlimefunItem '" + cfg.getString(itemPath + ".slimefun_item").toUpperCase(Locale.ROOT) + "' to CustomItem Surprise '" + name + "'");
+							}
+						} else if (cfg.getString(itemPath + ".type") != null && Material.getMaterial(cfg.getString(itemPath + ".type")) != null) {
 							item = new ItemStack(Material.getMaterial(cfg.getString(itemPath + ".type")));
 							ItemMeta itemMeta = item.getItemMeta();
 
@@ -263,6 +277,8 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 								}
 							}
 							item.setItemMeta(itemMeta);
+						}
+						if (item != null) {
 							items.add(item);
 						}
 					}

--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/SlimefunLuckyBlocks.java
@@ -142,63 +142,63 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 
 	private void registerSurprises() {
 		// Lucky Surprises
-		registerSuprise(new CookedFoodSurprise());
-		registerSuprise(new GoldenAppleSurprise());
-		registerSuprise(new DiamondBlockSurprise());
-		registerSuprise(new DiamondBlockPillarSurprise());
-		registerSuprise(new EmeraldBlockSurprise());
-		registerSuprise(new IronBlockSurprise());
-		registerSuprise(new TamedDogsSurprise());
-		registerSuprise(new TamedCatsSurprise());
-		registerSuprise(new ValuablesSurprise());
-		registerSuprise(new LuckySwordSurprise());
-		registerSuprise(new LuckyPickaxeSurprise());
-		registerSuprise(new LuckyAxeSurprise());
-		registerSuprise(new XPRainSurprise());
-		registerSuprise(new LuckyHelmetSurprise());
-		registerSuprise(new LuckyChestplateSurprise());
-		registerSuprise(new LuckyLeggingsSurprise());
-		registerSuprise(new LuckyBootsSurprise());
-		registerSuprise(new LuckyPotionsSurprise());
-		registerSuprise(new UnluckyPotionsSurprise());
-		registerSuprise(new CakeSurprise());
+		registerSurprise(new CookedFoodSurprise());
+		registerSurprise(new GoldenAppleSurprise());
+		registerSurprise(new DiamondBlockSurprise());
+		registerSurprise(new DiamondBlockPillarSurprise());
+		registerSurprise(new EmeraldBlockSurprise());
+		registerSurprise(new IronBlockSurprise());
+		registerSurprise(new TamedDogsSurprise());
+		registerSurprise(new TamedCatsSurprise());
+		registerSurprise(new ValuablesSurprise());
+		registerSurprise(new LuckySwordSurprise());
+		registerSurprise(new LuckyPickaxeSurprise());
+		registerSurprise(new LuckyAxeSurprise());
+		registerSurprise(new XPRainSurprise());
+		registerSurprise(new LuckyHelmetSurprise());
+		registerSurprise(new LuckyChestplateSurprise());
+		registerSurprise(new LuckyLeggingsSurprise());
+		registerSurprise(new LuckyBootsSurprise());
+		registerSurprise(new LuckyPotionsSurprise());
+		registerSurprise(new UnluckyPotionsSurprise());
+		registerSurprise(new CakeSurprise());
 		
 		// Neutral Surprises
-		registerSuprise(new GrootSurprise());
-		registerSuprise(new RawFoodSurprise());
-		registerSuprise(new FishSurprise());
-		registerSuprise(new WanderingTraderSurprise());
-		registerSuprise(new RainbowSheepSurprise());
-		registerSuprise(new ChickenRainSurprise());
-		registerSuprise(new DyeSurprise());
-		registerSuprise(new HaySurprise());
-		registerSuprise(new CookieSurprise());
-		registerSuprise(new JebSheepSurprise());
-		registerSuprise(new VillagersSurprise());
-		registerSuprise(new PotatOSSurprise());
-		registerSuprise(new JerrySlimeSurprise());
+		registerSurprise(new GrootSurprise());
+		registerSurprise(new RawFoodSurprise());
+		registerSurprise(new FishSurprise());
+		registerSurprise(new WanderingTraderSurprise());
+		registerSurprise(new RainbowSheepSurprise());
+		registerSurprise(new ChickenRainSurprise());
+		registerSurprise(new DyeSurprise());
+		registerSurprise(new HaySurprise());
+		registerSurprise(new CookieSurprise());
+		registerSurprise(new JebSheepSurprise());
+		registerSurprise(new VillagersSurprise());
+		registerSurprise(new PotatOSSurprise());
+		registerSurprise(new JerrySlimeSurprise());
 
 		// Unlucky Surprises
-		registerSuprise(new ChargedCreeperSurprise());
-		registerSuprise(new WitchSurprise());
-		registerSuprise(new ExplosionSurprise());
-		registerSuprise(new VoidHoleSurprise());
-		registerSuprise(new AnvilRainSurprise());
-		registerSuprise(new EnclosedWaterSurprise());
-		registerSuprise(new TNTRainSurprise());
-		registerSuprise(new FlyingCreeperSurprise());
-		registerSuprise(new FlyingTNTSurprise());
-		registerSuprise(new FakeDiamondBlock());
-		registerSuprise(new BryanZombieSurprise());
-		registerSuprise(new WalshrusSurprise());
-		registerSuprise(new HighJumpSurprise());
-		registerSuprise(new CobwebSurprise());
-		registerSuprise(new GiantSlimeSurprise());
-		registerSuprise(new ZombiePigmenSurprise());
+		registerSurprise(new ChargedCreeperSurprise());
+		registerSurprise(new WitchSurprise());
+		registerSurprise(new ExplosionSurprise());
+		registerSurprise(new VoidHoleSurprise());
+		registerSurprise(new AnvilRainSurprise());
+		registerSurprise(new EnclosedWaterSurprise());
+		registerSurprise(new TNTRainSurprise());
+		registerSurprise(new FlyingCreeperSurprise());
+		registerSurprise(new FlyingTNTSurprise());
+		registerSurprise(new FakeDiamondBlock());
+		registerSurprise(new BryanZombieSurprise());
+		registerSurprise(new WalshrusSurprise());
+		registerSurprise(new HighJumpSurprise());
+		registerSurprise(new CobwebSurprise());
+		registerSurprise(new GiantSlimeSurprise());
+		registerSurprise(new ZombiePigmenSurprise());
 		
 		// Pandora Box Surprises
-		registerSuprise(new ReapersSurprise());
-		registerSuprise(new IronGolemsSurprise());
+		registerSurprise(new ReapersSurprise());
+		registerSurprise(new IronGolemsSurprise());
 
 		// CustomItem Surprises
 		if (cfg.getValue("custom") != null && cfg.getKeys("custom").size() > 0) {
@@ -284,7 +284,7 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 					}
 
 					if (items.size() > 0) {
-						registerSuprise(new CustomItemSurprise(name, items, luckLevel));
+						registerSurprise(new CustomItemSurprise(name, items, luckLevel));
 					}
 				}
 			}
@@ -301,7 +301,7 @@ public class SlimefunLuckyBlocks extends JavaPlugin implements SlimefunAddon {
 		return potion;
 	}
 
-	public void registerSuprise(Surprise surprise) {
+	public void registerSurprise(Surprise surprise) {
 		if (surprise instanceof CustomItemSurprise) {
 			if (cfg.getBoolean("custom." + surprise.getName() + ".enabled")) {
 				surprises.add(surprise);

--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/surprises/CustomItemSurprise.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/surprises/CustomItemSurprise.java
@@ -1,0 +1,40 @@
+package io.github.thebusybiscuit.slimefunluckyblocks.surprises;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Random;
+
+public class CustomItemSurprise implements Surprise {
+
+    private String name;
+    private LuckLevel luckLevel;
+    private List<ItemStack> items;
+
+    public CustomItemSurprise(String name, List<ItemStack> items, LuckLevel luckLevel) {
+        this.name = name;
+        this.luckLevel = luckLevel;
+        this.items = items;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void activate(Random random, Player p, Location l) {
+        items.forEach(i -> {
+            l.getWorld().dropItemNaturally(l, i);
+        });
+    }
+
+    @Override
+    public LuckLevel getLuckLevel() {
+        return luckLevel;
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/surprises/CustomItemSurprise.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefunluckyblocks/surprises/CustomItemSurprise.java
@@ -10,9 +10,9 @@ import java.util.Random;
 
 public class CustomItemSurprise implements Surprise {
 
-    private String name;
-    private LuckLevel luckLevel;
-    private List<ItemStack> items;
+    private final String name;
+    private final LuckLevel luckLevel;
+    private final List<ItemStack> items;
 
     public CustomItemSurprise(String name, List<ItemStack> items, LuckLevel luckLevel) {
         this.name = name;
@@ -27,9 +27,9 @@ public class CustomItemSurprise implements Surprise {
 
     @Override
     public void activate(Random random, Player p, Location l) {
-        items.forEach(i -> {
+        for (ItemStack i : items) {
             l.getWorld().dropItemNaturally(l, i);
-        });
+        }
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@ world-blacklist:
 chance: 2
 debug: false
 custom:
-  ExampleSurprise:
+  ExampleSurprise1:
     enabled: false
     lucklevel: LUCKY
     items:
@@ -16,3 +16,10 @@ custom:
           - '&7This is the lore.'
         enchants:
           - DAMAGE_ALL:5
+  ExampleSurprise2:
+    enabled: false
+    lucklevel: LUCKY
+    items:
+      '1':
+        slimefun_item: 'BIRTHDAY_CAKE'
+        amount: 1

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,16 @@ world-blacklist:
 - world_the_end
 chance: 2
 debug: false
+custom:
+  ExampleSurprise:
+    enabled: false
+    lucklevel: LUCKY
+    items:
+      '1':
+        type: DIAMOND_SWORD
+        amount: 1
+        displayname: '&c&lExample Sword'
+        lore:
+          - '&7This is the lore.'
+        enchants:
+          - DAMAGE_ALL:5


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
It would be very cool if server owners could add custom surprises with custom items, so that's why I made these changes. We can add unlimited amount of CustomItem surprises in the config.yml under the ``custom`` path. I added an example surprise to the config, so everyone can understand how to add surprises.

Surprise settings:
- We can set the luck level and whether it's enabled.

Surprise Item settings:
- We can set: item type, amount, display name, lore, enchants. I think this customization is already enough, but correct me if I'm wrong.

## Changes
<!-- Please list all the changes you have made. -->
 - Added CustomItemSurprise.class: An object with the name, luck level and an item list of the surprise
- Changed SlimefunLuckyBlocks.class: Looping through all the custom surprises to register them if they're valid
- Changed config.yml: Added an example surprise

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A
## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those checkboxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I added sufficient Unit Tests to cover my code.